### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,3 @@ It install the Debian package and configures it with given settings.
 #### Setup
 
 - [Add the admin](http://wiki.mumble.info/wiki/Murmurguide#Connecting_to_Murmur_Server)
-
-email me at matlink@matlink.fr if you need something or to give me feedback about this app.

--- a/check_process
+++ b/check_process
@@ -23,3 +23,15 @@
 		fail_download_source=0
 		port_already_use=1
 		final_path_already_use=0
+;;; Levels
+	Level 1=auto
+	Level 2=auto
+	Level 3=auto
+	# https://github.com/YunoHost-Apps/mumbleserver_ynh/issues/11
+	Level 4=1
+	Level 5=auto
+	Level 6=auto
+	Level 7=auto
+	Level 8=0
+	Level 9=0
+	Level 10=0

--- a/manifest.json
+++ b/manifest.json
@@ -6,11 +6,14 @@
         "en": "Mumble is a libre, low-latency, high quality voice chat software primarily intended for use while gaming.",
         "fr": "Mumble est un logiciel libre de voix sur IP (VoIP), son principal usage étant la communication pendant les parties de jeux en réseau."
     },
-    "url": "http://mumble.info",
+    "url": "https://mumble.info",
     "license": "free",
     "maintainer": {
-        "name": "Matlink",
-        "email": "matlink@matlink.fr"
+        "name": "Moul",
+        "email": "moul@moul.re"
+    },
+    "requirements": {
+        "yunohost": ">> 2.4.0"
     },
     "multi_instance": false,
     "services": [

--- a/scripts/install
+++ b/scripts/install
@@ -31,21 +31,22 @@ fi
 # Save app settings
 ynh_app_setting_set $app port "$port"
 
-# install via apt-get
-sudo apt-get update > /dev/null 2>&1
-sudo apt-get install -y mumble-server > /dev/null 2>&1
+# Install Mumble Debian package via apt
+sudo apt update > /dev/null 2>&1
+sudo apt install -y mumble-server > /dev/null 2>&1
+
+# Configuring with given settings
+mumble_conf="../conf/mumble-server.ini"
+sudo sed -i "s/welcometext=.*/welcometext=$welcometext/g" $mumble_conf
+sudo sed -i "s/port=.*/port=$port/g" $mumble_conf
+sudo sed -i "s/serverpassword=.*/serverpassword=$server_password/g" $mumble_conf
+sudo sed -i "s/#registerName=.*/registerName=$registerName/g" $mumble_conf
 
 # Copying conf file
 mumble_conf="/etc/mumble-server.ini"
 sudo cp ../conf/mumble-server.ini $mumble_conf
 sudo chmod 660  $mumble_conf
 sudo chown :mumble-server $mumble_conf
-
-#configuring with given settings
-sudo sed -i "s/welcometext=.*/welcometext=$welcometext/g" $mumble_conf
-sudo sed -i "s/port=.*/port=$port/g" $mumble_conf
-sudo sed -i "s/serverpassword=.*/serverpassword=$server_password/g" $mumble_conf
-sudo sed -i "s/#registerName=.*/registerName=$registerName/g" $mumble_conf
 
 #open port in firewall
 sudo yunohost firewall allow Both $port > /dev/null 2>&1

--- a/scripts/install
+++ b/scripts/install
@@ -37,10 +37,10 @@ sudo apt install -y mumble-server > /dev/null 2>&1
 
 # Configuring with given settings
 mumble_conf="../conf/mumble-server.ini"
-sudo sed -i "s/welcometext=.*/welcometext=$welcometext/g" $mumble_conf
-sudo sed -i "s/port=.*/port=$port/g" $mumble_conf
-sudo sed -i "s/serverpassword=.*/serverpassword=$server_password/g" $mumble_conf
-sudo sed -i "s/#registerName=.*/registerName=$registerName/g" $mumble_conf
+sudo sed -i "s/welcometext=.*/welcometext=$welcometext/" $mumble_conf
+sudo sed -i "s/port=.*/port=$port/" $mumble_conf
+sudo sed -i "s/serverpassword=.*/serverpassword=$server_password/" $mumble_conf
+sudo sed -i "s/#registerName=.*/registerName=$registerName/" $mumble_conf
 
 # Copying conf file
 mumble_conf="/etc/mumble-server.ini"

--- a/scripts/install
+++ b/scripts/install
@@ -20,12 +20,12 @@ source /usr/share/yunohost/helpers
 # Check port availability
 sudo yunohost app checkport $port
 if [[ ! $? -eq 0 ]]; then
-	exit 1
+	ynh_die
 fi
 
 # Check if su_password is not empty
 if [[ -z "$su_passwd" ]]; then
-	exit 1
+	ynh_die
 fi
 
 # Save app settings

--- a/scripts/install
+++ b/scripts/install
@@ -48,17 +48,17 @@ sudo cp ../conf/mumble-server.ini $mumble_conf
 sudo chmod 660  $mumble_conf
 sudo chown :mumble-server $mumble_conf
 
-#open port in firewall
+# Open port in firewall
 sudo yunohost firewall allow Both $port > /dev/null 2>&1
-sudo yunohost firewall allow --ipv6 Both $port > /dev/null 2>&1
 
-#starting mumble server 
+# Start Mumble server
 sudo /etc/init.d/mumble-server start
 
-#setting super-user password
+# Set super-user password
 sudo murmurd -supw $su_passwd
-#restart mumble server
+
+# Restart Mumble server
 sudo /etc/init.d/mumble-server restart
 
-#adding mumble as a service
+# Add Mumble as a YunoHost service
 sudo yunohost service add mumble-server -l /var/log/mumble-server/mumble-server.log

--- a/scripts/install
+++ b/scripts/install
@@ -1,17 +1,18 @@
 #!/bin/bash
-
 #debug commands
 #exec > >(tee /tmp/mumble-install.log)
 #exec 2>&1
 
-app=mumbleserver
+# Exit on command errors and treat unset variables as an error
+set -eu
 
 # Retrieve arguments
-server_password=$1
-su_passwd=$2
-welcometext=$3
-port=$4
-registerName=$5
+app="mumbleserver"
+server_password=$YNH_APP_ARG_SERVER_LOGIN_PASSWORD
+su_passwd=$YNH_APP_ARG_PASSWORD
+welcometext=$YNH_APP_ARG_WELCOMETEXT
+port=$YNH_APP_ARG_PORT
+registerName=$YNH_APP_ARG_REGISTERNAME
 
 # Source YunoHost helpers
 source /usr/share/yunohost/helpers

--- a/scripts/install
+++ b/scripts/install
@@ -13,26 +13,29 @@ welcometext=$3
 port=$4
 registerName=$5
 
-mumble_conf=/etc/mumble-server.ini
+# Source YunoHost helpers
+source /usr/share/yunohost/helpers
+
 # Check port availability
 sudo yunohost app checkport $port
 if [[ ! $? -eq 0 ]]; then
 	exit 1
 fi
 
-#check if su_password is not empty
+# Check if su_password is not empty
 if [[ -z "$su_passwd" ]]; then
 	exit 1
 fi
 
 # Save app settings
-sudo yunohost app setting $app port -v "$port"
+ynh_app_setting_set $app port "$port"
 
 # install via apt-get
 sudo apt-get update > /dev/null 2>&1
 sudo apt-get install -y mumble-server > /dev/null 2>&1
 
-#copying conf file
+# Copying conf file
+mumble_conf="/etc/mumble-server.ini"
 sudo cp ../conf/mumble-server.ini $mumble_conf
 sudo chmod 660  $mumble_conf
 sudo chown :mumble-server $mumble_conf

--- a/scripts/remove
+++ b/scripts/remove
@@ -11,12 +11,11 @@ app=mumbleserver
 # Getting port used by mumble to close it
 port=$(ynh_app_setting_get $app port)
 
-# Uninstall mumble and its dependencies
-sudo apt-get autoremove -y mumble-server > /dev/null 2>&1
+# Uninstall Mumble and its dependencies
+sudo apt autoremove -y mumble-server > /dev/null 2>&1
 
 # Close ports
 sudo yunohost firewall disallow Both $port > /dev/null 2>&1
-sudo yunohost firewall disallow --ipv6 Both $port > /dev/null 2>&1
 
 # Removing config file
 sudo rm -f /etc/mumble-server.ini

--- a/scripts/remove
+++ b/scripts/remove
@@ -1,14 +1,18 @@
 #!/bin/bash
 
 app=mumbleserver
-#getting port used by mumble to close it
+
+# Getting port used by mumble to close it
 port=$(sudo yunohost app setting $app port)
-#uninstall mumble and its dependencies
+
+# Uninstall mumble and its dependencies
 sudo apt-get autoremove -y mumble-server > /dev/null 2>&1
-#close ports
+
+# Close ports
 sudo yunohost firewall disallow Both $port > /dev/null 2>&1
 sudo yunohost firewall disallow --ipv6 Both $port > /dev/null 2>&1
-#removing config file 
+
+# Removing config file
 sudo rm -f /etc/mumble-server.ini
 
 # Remove mumble-server service

--- a/scripts/remove
+++ b/scripts/remove
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+# Exit and treat unset variables as an error
+set -u
+
+# Source YunoHost helpers
+source /usr/share/yunohost/helpers
+
 app=mumbleserver
 
 # Getting port used by mumble to close it
-port=$(sudo yunohost app setting $app port)
+port=$(ynh_app_setting_get $app port)
 
 # Uninstall mumble and its dependencies
 sudo apt-get autoremove -y mumble-server > /dev/null 2>&1

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,2 +1,4 @@
 #!/bin/bash
 
+# Exit on command errors and treat unset variables as an error
+set -eu


### PR DESCRIPTION
- [Manually force level 4](https://github.com/YunoHost/package_check#-levels).
- Linter is :ok: which validate level 5
- [fix] Remove double `firewall allow`.
- [fix] Modify configuration file, and then move it.
- set myself as maintainer.

---
The app [should go level 6](https://ci-apps.yunohost.org/jenkins/job/mumbleserver%20(Community)/lastBuild/consoleFull) and could pretend [official integration](https://github.com/YunoHost-Apps/mumbleserver_ynh/issues/10).