### PR TITLE
[fix] The directory holding the PID file is not created

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,6 +7,7 @@ After=network.target
 User=mumble-server
 Group=mumble-server
 Type=forking
+ExecStartPre=mkdir -p /var/run/mumble-server
 ExecStart=/usr/sbin/murmurd -ini __FINALPATH__/mumble-server.ini
 PIDFile=/var/run/mumble-server/__APP__.pid
 ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
It is created at install time, but on systems where
/var/run is a tmpfs, this does not survive a restart,
thus preventing mumble-server to start.

This is the case for LXD containers, where /var/run is
a tmpfs by default.