### PR TITLE
[buster] Patch murmurd exit for buster version

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -121,7 +121,9 @@ usermod --append --groups ssl-cert mumble-server
 # Set SuperUser password
 #=================================================
 
-murmurd -ini "$mumble_conf" -supw "$su_passwd" "$instance_id"
+# || true temporarily to ignore a bug in murmurd 1.3.0
+# https://github.com/mumble-voip/mumble/issues/3911
+murmurd -ini "$mumble_conf" -supw "$su_passwd" "$instance_id" || true
 
 #=================================================
 # Disable default server installed by Debian's package

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -169,7 +169,9 @@ usermod --append --groups ssl-cert mumble-server
 # Set SuperUser password
 #=================================================
 
-murmurd -ini "$mumble_conf" -supw "$su_passwd" "$instance_id"
+# || true temporarily to ignore a bug in murmurd 1.3.0
+# https://github.com/mumble-voip/mumble/issues/3911
+murmurd -ini "$mumble_conf" -supw "$su_passwd" "$instance_id" || true
 
 #=================================================
 # Disable default server installed by Debian's package


### PR DESCRIPTION
Fix https://github.com/YunoHost-Apps/mumbleserver_ynh/issues/33

murmurd return 1 when used with -supw.